### PR TITLE
Added global triggers support

### DIFF
--- a/src/spigot-1.16.1/procedures/_cancel_event.java.ftl
+++ b/src/spigot-1.16.1/procedures/_cancel_event.java.ftl
@@ -1,0 +1,6 @@
+if(dependencies.get("event")!=null){
+	Object _obj = dependencies.get("event");
+	if(_obj instanceof Cancellable) {
+		((Cancellable) _obj).setCancelled(true);
+	}
+}

--- a/src/spigot-1.16.1/templates/modbase/mod.java.ftl
+++ b/src/spigot-1.16.1/templates/modbase/mod.java.ftl
@@ -22,7 +22,11 @@ public class ${JavaModName} extends JavaPlugin {
   public void onEnable()
   {
     <#list w.getElementsOfType("COMMAND") as command>
-    this.getCommand("${command}").setExecutor(new ${command}());
+		this.getCommand("${command}").setExecutor(new ${command}());
+    </#list>
+	
+	<#list w.getElementsOfType("PROCEDURE") as procedure>
+		getServer().getPluginManager().registerEvents(new ${procedure.getName()}Procedure(), this);
     </#list>
   }
 

--- a/src/spigot-1.16.1/templates/procedure.java.ftl
+++ b/src/spigot-1.16.1/templates/procedure.java.ftl
@@ -3,7 +3,7 @@ package ${package}.procedures;
 
 import org.bukkit.entity.Entity;
 
-public class ${name}Procedure <#if has_trigger>implements org.bukkit.event.Listener</#if> {
+public class ${name}Procedure implements org.bukkit.event.Listener {
 
 	public static <#if return_type??>${return_type.getJavaType(generator.getWorkspace())}<#else>void</#if> executeProcedure(Map<String, Object> dependencies){
 		<#list dependencies as dependency>

--- a/src/spigot-1.16.1/triggers/block_break.java.ftl
+++ b/src/spigot-1.16.1/triggers/block_break.java.ftl
@@ -1,0 +1,15 @@
+@EventHandler public void onBlockBreak(BlockBreakEvent event) {
+	World world=event.getPlayer().getWorld();
+	Entity entity=event.getPlayer();
+	double i=event.getBlock().getLocation().getX();
+	double j=event.getBlock().getLocation().getY();
+	double k=event.getBlock().getLocation().getZ();
+	Map<String, Object> dependencies = new HashMap<>();
+	dependencies.put("x",i);
+	dependencies.put("y",j);
+	dependencies.put("z",k);
+	dependencies.put("world",world);
+	dependencies.put("entity",entity);
+	dependencies.put("event",event);
+	this.executeProcedure(dependencies);
+}

--- a/src/spigot-1.16.1/triggers/player_log_in.java.ftl
+++ b/src/spigot-1.16.1/triggers/player_log_in.java.ftl
@@ -1,0 +1,15 @@
+@EventHandler public void onPlayerJoin(PlayerJoinEvent event) {
+	World world=event.getPlayer().getWorld();
+	Entity entity=event.getPlayer();
+	double i=entity.getLocation().getX();
+	double j=entity.getLocation().getY();
+	double k=entity.getLocation().getZ();
+	Map<String, Object> dependencies = new HashMap<>();
+	dependencies.put("x",i);
+	dependencies.put("y",j);
+	dependencies.put("z",k);
+	dependencies.put("world",world);
+	dependencies.put("entity",entity);
+	dependencies.put("event",event);
+	this.executeProcedure(dependencies);
+}


### PR DESCRIPTION
Due to the way MCreator handles procedures, it is not possible to determine if the procedure has global trigger or not so all procedures are registered as listeners. There should be no performance impacts due to this during runtime, but possibly a really minor impact on startup if there would be hundreds of procedures in a plugin.