### PR TITLE
Added support to test plugins inside MCreator

### DIFF
--- a/src/spigot-1.16.1/generator.yaml
+++ b/src/spigot-1.16.1/generator.yaml
@@ -2,10 +2,12 @@ name: Minecraft Spigot for 1.16.1
 basefeatures: []
 partial_support: []
 status: dev
-buildfileversion: 1.0.1
+buildfileversion: 1.1.0
 
 gradle:
   export_file: "build/libs/plugin.jar"
+  run_server: runSpigotServer
+  setup_task: "dependencies buildLatestSpigot --refresh-dependencies"
 
 source_root: "@WORKSPACEROOT/src/main/java"
 res_root: "@WORKSPACEROOT/src/main/resources"

--- a/src/spigot-1.16.1/workspacebase/build.gradle
+++ b/src/spigot-1.16.1/workspacebase/build.gradle
@@ -1,12 +1,12 @@
 plugins {
     id 'java'
+	id "de.undercouch.download" version "4.1.1"
 }
 
 group 'com.yourname.modid'
 version '1.0'
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven {
         url "https://hub.spigotmc.org/nexus/content/repositories/snapshots"
@@ -19,4 +19,35 @@ dependencies {
 
 jar {
     archiveFileName = 'plugin.jar'
+}
+
+task buildLatestSpigot(type: de.undercouch.gradle.tasks.download.Download)  {
+	src 'https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar'
+    dest 'build/btmp/BuildTools.jar'
+	doLast {
+		javaexec { 
+			main = "-jar"
+			args = [ "BuildTools.jar", "--rev", "1.16.1" ]
+			workingDir = "build/btmp"
+		}
+		copy { 
+			from file('build/btmp/spigot-1.16.1.jar')
+			into file('run/')
+		}
+		delete files('build/btmp')
+	}
+}
+
+task runSpigotServer (dependsOn: build) {
+	doLast {
+		copy {
+			from file('build/libs/plugin.jar')
+			into file('run/plugins/')
+		}
+		javaexec { 
+			main = "-jar"
+			args = [ "spigot-1.16.1.jar" ]
+			workingDir = "run/"
+		}
+	}
 }


### PR DESCRIPTION
Added support to run the server in MCreator.

To make sure the latest 1.16.1 spigot is used, the spigot is built during setup. Specified setup task for this.